### PR TITLE
模板示例 tips值改为双引号，内部单引号

### DIFF
--- a/aform.config.js
+++ b/aform.config.js
@@ -35,7 +35,7 @@ AForm.Config.extClassName = {
 };
 //模板
 AForm.Config.tpl = {
-	"tips" : '&nbsp;<a title="{tips}" href="#nolink">[?]</a>',
+	"tips" : "&nbsp;<a title='{tips}' href='#nolink'>[?]</a>",
 	"thTips" : "<sup title='{tips}'>[?]</sup>"
 };
 //术语


### PR DESCRIPTION
demo 加载后，手动调整配置项的值，点击【生成表单】会无法解析。改为双引号可正常解析。